### PR TITLE
Avoid SSL errors: Add --insecure (-k) option to curl.

### DIFF
--- a/check_wp_update
+++ b/check_wp_update
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 CURL=`which curl`
-CURL_OPTS='--user-agent check-wp-updates-nagios-plugin'
+CURL_OPTS='--user-agent check-wp-updates-nagios-plugin --insecure'
 BASENAME=`which basename`
 PROGNAME=`$BASENAME $0`
 


### PR DESCRIPTION
The --insecure (-k) option prevents SSL errors (e. g. self signed certificates). The check_wp_update alerts a CRITICAL state by SSL errors. There are many plugins out there to check a valid SSL connection.