### PR TITLE
Curl progress meter fix and modifications to fit Nagios plugin guidelines

### DIFF
--- a/check_wp_update
+++ b/check_wp_update
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 CURL=`which curl`
-CURL_OPTS='--user-agent check-wp-updates-nagios-plugin --insecure'
+CURL_OPTS='-s --user-agent check-wp-updates-nagios-plugin --insecure'
 BASENAME=`which basename`
 PROGNAME=`$BASENAME $0`
 

--- a/check_wp_update
+++ b/check_wp_update
@@ -18,22 +18,22 @@ function print_usage
 
 if [ ! $1 ]; then
     print_usage
-    exit $STATE_CRITICAL
+    exit $STATE_UNKNOWN
 fi
 
 # Check that we're getting a 200 OK message for the wp-version.php file on the remote host.
 response=`$CURL $CURL_OPTS -I $1`
 if [[ ( $response != *"200 OK"* && $response != *"HTTP/2 200"* ) ]]; then
-    echo 'CRITICAL - Checker Script not installed on remote host'
-    exit $STATE_CRITICAL
+    echo 'UNKNOWN - Checker Script not installed on remote host'
+    exit $STATE_UNKNOWN
 fi
 
 
 result=`$CURL $CURL_OPTS -s $1`
 
 if [ $? != 0 ]; then
-    echo 'CRITICAL - Check plugin does not work. Maybe you need to install curl.'
-    exit $STATE_CRITICAL
+    echo 'UNKNOWN - Check plugin does not work. Maybe you need to install curl.'
+    exit $STATE_UNKNOWN
 else
     status=`echo $result | cut -d\# -f1`
     text=`echo $result | cut -d\# -f2`


### PR DESCRIPTION
Fixes #15
Fixes #16

Added -s (silent) to CURL_OTPS to suppress curl progress meter in output (Issue:#15)

Also changed some STATE_CRITICAL to STATE_UNKNOWN to fit Nagios plugin guidelines (Issue:#16)
