### PR TITLE
ensure PHP 8 compatibility

### DIFF
--- a/wp-version.php
+++ b/wp-version.php
@@ -86,4 +86,4 @@ if ($core_available) {
     $status = 'WARNING';
 }
 
-echo $status . '#' . implode($text, ';');
+echo $status . '#' . implode(';', $text);


### PR DESCRIPTION
The legacy signature of implode is removed in PHP 8.