### PR TITLE
Added CURL --location for redirect

### DIFF
--- a/check_wp_update
+++ b/check_wp_update
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 CURL=`which curl`
-CURL_OPTS='-s --user-agent check-wp-updates-nagios-plugin --insecure'
+CURL_OPTS='-s --location --user-agent check-wp-updates-nagios-plugin --insecure'
 BASENAME=`which basename`
 PROGNAME=`$BASENAME $0`
 


### PR DESCRIPTION
Sometimes a Wordpress URL has a redirect in it. In that case the check is never processed as the HTTP result is 301, not 200. Easy fix by adding the "--location" flag to the CURL command.